### PR TITLE
Fix a typo in the AJAX call question

### DIFF
--- a/README.md
+++ b/README.md
@@ -2942,7 +2942,7 @@
              <ul>
                {employees.map(item => (
                  <li key={employee.name}>
-                   {employee.name}-{employees.experience}
+                   {employee.name}-{employee.experience}
                  </li>
                ))}
              </ul>

--- a/README.md
+++ b/README.md
@@ -2940,7 +2940,7 @@
          } else {
            return (
              <ul>
-               {employees.map(item => (
+               {employees.map(employee => (
                  <li key={employee.name}>
                    {employee.name}-{employee.experience}
                  </li>


### PR DESCRIPTION
Found a typo in the code example in the **AJAX call question**, where the author used the `employees` array instead of the extracted `employee` object to access the experience property.