### PR TITLE
Minor fix to remove title out of Message component

### DIFF
--- a/README.md
+++ b/README.md
@@ -6920,7 +6920,7 @@ const loadUser = async () => {
      Wrapper component can also accept its own props and pass them down to the wrapped component, for example, we can create a wrapper component that will add a title to the message component:
 
      ```javascript
-     const MessageWrapperWithTitle = (props) => {
+     const MessageWrapperWithTitle = ({title, ...props}) => {
        return (
          <div>
            <h3>{props.title}</h3>


### PR DESCRIPTION
The `Message` doesn't support `title` prop so it is redundant (and will create warning). 

```javascript
const Message = ({ text }) => {
  return <p>{text}</p>;
};
```

This PR extracts the `title` out of `props` to avoid the warning. 