### PR TITLE
Minor fix on Wrapped Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -6923,7 +6923,7 @@ const loadUser = async () => {
      const MessageWrapperWithTitle = ({title, ...props}) => {
        return (
          <div>
-           <h3>{props.title}</h3>
+           <h3>{title}</h3>
            <Message {...props} />
          </div>
        );

--- a/README.md
+++ b/README.md
@@ -6920,7 +6920,7 @@ const loadUser = async () => {
      Wrapper component can also accept its own props and pass them down to the wrapped component, for example, we can create a wrapper component that will add a title to the message component:
 
      ```javascript
-     const MessageWrapperWithTitle = (props) => {
+     const MessageWrapperWithTitle = ({title, ...props}) => {
        return (
          <div>
            <h3>{props.title}</h3>


### PR DESCRIPTION
The `Message` component doesn't accept `title` prop. 
```javascript
const Message = ({ text }) => {
  return <p>{text}</p>;
};
```

Passing all props to it from the wrapping component will create warning. 
```javascript
const MessageWrapperWithTitle = (props) => {
  return (
    <div>
      <h3>{props.title}</h3>
      <Message {...props} />
    </div>
  );
};
```

This PR helps to avoid that. 
