### PR TITLE
Fix some styling issues in q335 and q336

### DIFF
--- a/README.md
+++ b/README.md
@@ -7093,7 +7093,7 @@ const loadUser = async () => {
       State contains information or data about a component which may change over time. 
       
       In class component, you can update the state when a user interacts with it or server updates the data using the `setState()` method. The initial state is going to be assigned in the `Constructor( ) `method using the the ` this.state` object and it is possible to different data types in the `this.state` object such as string, boolean, numbers, etc.
-      ** A simple example showing how we use the setState() and constructor() **
+      **A simple example showing how we use the setState() and constructor()**
 
       ```
       class App extends Component {

--- a/README.md
+++ b/README.md
@@ -7093,7 +7093,7 @@ const loadUser = async () => {
       State contains information or data about a component which may change over time. 
       
       In class component, you can update the state when a user interacts with it or server updates the data using the `setState()` method. The initial state is going to be assigned in the `Constructor( ) `method using the the ` this.state` object and it is possible to different data types in the `this.state` object such as string, boolean, numbers, etc.
-      <strong> A simple example showing how we use the setState() and constructor() <strong>
+      ** A simple example showing how we use the setState() and constructor() **
 
       ```
       class App extends Component {

--- a/README.md
+++ b/README.md
@@ -7186,7 +7186,7 @@ const loadUser = async () => {
       }
       ```
 
-  **[⬆ Back to Top](#table-of-contents)**
+**[⬆ Back to Top](#table-of-contents)**
 
 336. ### Why does strict mode render twice in React?
       StrictMode renders components twice in development mode(not production) in order to detect any problems with your code and warn you about those problems. This is used to detect accidental side effects in the render phase.  If you used `create-react-app` development tool then it automatically enables StrictMode by default.
@@ -7216,7 +7216,7 @@ const loadUser = async () => {
       4. State updater functions
       5. Functions passed to useState, useMemo, or useReducer (any Hook)
 
-      **[⬆ Back to Top](#table-of-contents)**
+**[⬆ Back to Top](#table-of-contents)**
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -7067,7 +7067,7 @@ const loadUser = async () => {
       The classs components uses ES6 classes to create the components. It uses `render` function to display the HTML content in the webpage.
       
       The syntax for class component looks like as below.
-        ```
+        ```js
         class App extends Reacts.Component {
           render(){
             return <h1>This is a class component</h1>}
@@ -7079,7 +7079,7 @@ const loadUser = async () => {
 
       Functional component has been improved over the years with some added features like Hooks. Here is a syntax for functional component.
 
-      ```
+      ```js
       function App(){
         return <div className="App">
           <h1>Hello, I'm a function component</h1>
@@ -7095,7 +7095,7 @@ const loadUser = async () => {
       In class component, you can update the state when a user interacts with it or server updates the data using the `setState()` method. The initial state is going to be assigned in the `Constructor( ) `method using the the ` this.state` object and it is possible to different data types in the `this.state` object such as string, boolean, numbers, etc.
       **A simple example showing how we use the setState() and constructor()**
 
-      ```
+      ```js
       class App extends Component {
         constructor() {
           super();
@@ -7131,7 +7131,7 @@ const loadUser = async () => {
       
       Let's see an example to demonstrate the state in functional components,
 
-      ```
+      ```js
       function App() {
         const [message, setMessage] = useState("This is a functional component");
         const updateMessage = () => {
@@ -7150,7 +7150,7 @@ const loadUser = async () => {
       Props are referred to as "properties". The props are passed into react component just like arguments passed to a function. In otherwords, they are similar to HTML attributes. 
 
       The props are accessible in child class component using `this.props` as shown in below example,
-      ```
+      ```js
       class Child extends React.Component {
         render() {
           return <h1> This is a functional component and component name is {this.props.name} </h1>;
@@ -7171,7 +7171,7 @@ const loadUser = async () => {
 
       Props in functional components are similar to that of the class components but the difference is the absence of 'this' keyword. 
 
-      ```
+      ```js
       function Child(props) {
         return <h1>This is a child component and the component name is{props.name}</h1>;
       }
@@ -7189,36 +7189,34 @@ const loadUser = async () => {
   **[⬆ Back to Top](#table-of-contents)**
 
 336. ### Why does strict mode render twice in React?
+      StrictMode renders components twice in development mode(not production) in order to detect any problems with your code and warn you about those problems. This is used to detect accidental side effects in the render phase.  If you used `create-react-app` development tool then it automatically enables StrictMode by default.
 
-    StrictMode renders components twice in development mode(not production) in order to detect any problems with your code and warn you about those problems. This is used to detect accidental side effects in the render phase.  If you used `create-react-app` development tool then it automatically enables StrictMode by default.
-
-    ```js
+      ```js
       ReactDOM.render(
         <React.StrictMode>
           {App}
         </React.StrictMode>,
         document.getElementById('root')
       );
-    ```
+      ```
 
-    If you want to disable this behavior then you can remove `strict` mode.
-        ```js
+      If you want to disable this behavior then you can remove `strict` mode.
+      ```js
       ReactDOM.render(
-          {App}, 
+        {App}, 
         document.getElementById('root')
       );
-    ```
+      ```
 
-    To detect side effects the following functions are invoked twice:
+      To detect side effects the following functions are invoked twice:
 
-    1. Class component constructor, render, and shouldComponentUpdate methods
-    2. Class component static getDerivedStateFromProps method
-    3. Function component bodies
-    4. State updater functions
-    5. Functions passed to useState, useMemo, or useReducer (any Hook)
+      1. Class component constructor, render, and shouldComponentUpdate methods
+      2. Class component static getDerivedStateFromProps method
+      3. Function component bodies
+      4. State updater functions
+      5. Functions passed to useState, useMemo, or useReducer (any Hook)
 
-    **[⬆ Back to Top](#table-of-contents)**
-
+      **[⬆ Back to Top](#table-of-contents)**
 
 ## Disclaimer
 
@@ -7227,4 +7225,3 @@ The questions provided in this repository are the summary of frequently asked qu
 Good luck with your interview 😊
 
 ---
-```


### PR DESCRIPTION
Hi!

A little PR to fix some styling issues:

- The closing `strong` tag in q335 wasn't closed properly. Because of that, the following questions were in bold. I replaced the `<strong>` tags with the markdown equivalent for more consistency.
- Some code blocks were missing the `js` tag
- Indentation in q336 was not right


Also, thank you sincerly your work here, you can't imagine how much it helped me!