### PR TITLE
resolved confusion in "key" prop section

### DIFF
--- a/README.md
+++ b/README.md
@@ -939,7 +939,7 @@
 
 18. ### What is "key" prop and what is the benefit of using it in arrays of elements?
 
-    A `key` is a special attribute you **should** include when creating arrays of elements. _Key_ prop helps React identify which items have changed, are added, or are removed.
+    A `key` is a special attribute you **should** include when mapping over arrays to render data. _Key_ prop helps React identify which items have changed, are added, or are removed.
 
     Keys should be unique among its siblings. Most often we use ID from our data as _key_:
 


### PR DESCRIPTION
stating the "key" prop should be provided when creating arrays in reactjs is a little confusing and misleading. you don't need to provide it EVERY time you create an array; it is needed when you are using map to render data in array.