### PR TITLE
fix(Question 31): add code syntax to Fragment, delete redundant word

### DIFF
--- a/README.md
+++ b/README.md
@@ -1297,7 +1297,7 @@ class ParentComponent extends React.Component {
     }
     ```
 
-    Usually, you don't need to use **<Fragment>** until unless there is a need of _key_ attribute. The usage of shorter syntax looks like below.
+    Usually, you don't need to use `<Fragment>` until there is a need of _key_ attribute. The usage of shorter syntax looks like below.
 
     ```jsx harmony
     function Story({ title, description, date }) {


### PR DESCRIPTION
- "< Fragment>" is not currently rendering in the Preview in GitHub, it needs the code syntax with tildes `
- deleted redundant "unless" word and kept "until", i think it makes it clearer 