### PR TITLE
Fix typo in Q 252: 'creatRoot' → 'createRoot' in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5958,7 +5958,7 @@ class ParentComponent extends React.Component {
 
      1. **Triggering or initiating a render:** The component is going to triggered for render in two ways.
 
-        1. **Initial render:** When the app starts, you can trigger the initial render by calling `creatRoot` with the target DOM node followed by invoking component's `render` method. For example, the following code snippet renders `App` component on root DOM node.
+        1. **Initial render:** When the app starts, you can trigger the initial render by calling `createRoot` with the target DOM node followed by invoking component's `render` method. For example, the following code snippet renders `App` component on root DOM node.
 
         ```jsx
         import { createRoot } from "react-dom/client";


### PR DESCRIPTION
This pull request fixes a small typo in question 252 of the documentation.

- Incorrect: `creatRoot`
- Correct: `createRoot`

This change corrects the usage of the React `createRoot` method in the explanation of how React updates the UI.

This is my first contribution to the project — happy to help improve the documentation!
