### PR TITLE
Fix cleanup for custom hooks exercise

### DIFF
--- a/coding-exercise/src/App.test.js
+++ b/coding-exercise/src/App.test.js
@@ -2,8 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders the coding exercises home page', () => {
   const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(getByText('React Coding Exercises')).toBeInTheDocument();
 });

--- a/coding-exercise/src/exercises/exercise-04-custom-hooks/Problem.js
+++ b/coding-exercise/src/exercises/exercise-04-custom-hooks/Problem.js
@@ -27,7 +27,7 @@ function UserProfile() {
   useEffect(() => {
     setLoading(true);
     // Simulating API call
-    setTimeout(() => {
+    const timerId = setTimeout(() => {
       try {
         setData({ name: 'John Doe', email: 'john@example.com' });
         setLoading(false);
@@ -36,6 +36,8 @@ function UserProfile() {
         setLoading(false);
       }
     }, 1000);
+
+    return () => clearTimeout(timerId);
   }, []);
 
   if (loading) return <div>Loading user...</div>;
@@ -58,7 +60,7 @@ function PostsList() {
   useEffect(() => {
     setLoading(true);
     // Simulating API call
-    setTimeout(() => {
+    const timerId = setTimeout(() => {
       try {
         setData([
           { id: 1, title: 'First Post' },
@@ -70,6 +72,8 @@ function PostsList() {
         setLoading(false);
       }
     }, 1000);
+
+    return () => clearTimeout(timerId);
   }, []);
 
   if (loading) return <div>Loading posts...</div>;

--- a/coding-exercise/src/exercises/exercise-04-custom-hooks/Problem.test.js
+++ b/coding-exercise/src/exercises/exercise-04-custom-hooks/Problem.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import Problem from './Problem';
+
+describe('custom hooks problem', () => {
+  let consoleError;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+    jest.useRealTimers();
+  });
+
+  test('does not update state after unmounting', () => {
+    const { unmount } = render(<Problem />);
+
+    unmount();
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const hasUnmountedUpdateWarning = consoleError.mock.calls.some(([message]) =>
+      /state update on an unmounted component/i.test(String(message))
+    );
+
+    expect(hasUnmountedUpdateWarning).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Cancel the simulated request timers when the custom-hooks exercise unmounts.
- Replace the stale Create React App smoke assertion with the current landing-page heading.
- Add a regression test covering navigation away before the simulated requests complete.

## Root cause

Both simulated requests could outlive their components and attempt state updates after navigation.

## Validation

- `git diff --check`
